### PR TITLE
Initial commit / v 1.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+#
+# Exclude these files from release archives.
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/.github/ export-ignore
+/Test/ export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,9 @@
+<!--
+This repository is only for the PHPCompatibilityParagonie rulesets, which prevent false positives from the PHPCompatibility standard by excluding the poly-fills which are provided by the various Paragonie polyfill libraries.
+
+If your issue is related to the PHPCompatibility sniffs, please open an issue in the PHPCompatibility repository: https://github.com/PHPCompatibility/PHPCompatibility/issues
+
+Before opening a new issue, please search for your issue to prevent opening a duplicate. If there is already an open issue, please leave a comment there.
+
+Thanks!
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+sudo: false
+
+dist: trusty
+
+cache:
+  apt: true
+
+language: php
+
+## Cache composer downloads.
+cache:
+  directories:
+    - $HOME/.cache/composer/files
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.2
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
+    - php: 5.4
+
+before_install:
+  # Speed up build time by disabling Xdebug when its not needed.
+  - if [[ $COVERALLS_VERSION == "notset" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
+  - export XMLLINT_INDENT="    "
+  - composer install
+  - vendor/bin/phpcs -i
+
+script:
+  - |
+    if [[ $TRAVIS_PHP_VERSION == "7.2" ]]; then
+      # Validate the xml files.
+      # @link http://xmlsoft.org/xmllint.html
+      xmllint --noout ./*/ruleset.xml
+
+      # Check the code-style consistency of the xml files.
+      diff -B ./PHPCompatibilityParagonieRandomCompat/ruleset.xml <(xmllint --format "./PHPCompatibilityParagonieRandomCompat/ruleset.xml")
+      diff -B ./PHPCompatibilityParagonieSodiumCompat/ruleset.xml <(xmllint --format "./PHPCompatibilityParagonieSodiumCompat/ruleset.xml")
+    fi
+
+  # Test the rulesets.
+  - vendor/bin/phpcs ./Test/ParagonieRandomCompatTest.php --standard=PHPCompatibilityParagonieRandomCompat --runtime-set testVersion 5.2
+  - vendor/bin/phpcs ./Test/ParagonieSodiumCompatTest.php --standard=PHPCompatibilityParagonieSodiumCompat --runtime-set testVersion 5.3
+
+  # Validate the composer.json file.
+  # @link https://getcomposer.org/doc/03-cli.md#validate
+  - composer validate --no-check-all --strict

--- a/PHPCompatibilityParagonieRandomCompat/ruleset.xml
+++ b/PHPCompatibilityParagonieRandomCompat/ruleset.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCompatibilityParagonieRandomCompat">
+    <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Paragonie random_compat library.</description>
+
+    <rule ref="PHPCompatibility">
+        <!-- https://github.com/paragonie/random_compat/blob/master/lib/random.php -->
+        <exclude name="PHPCompatibility.Constants.NewConstants.php_version_idFound"/>
+
+        <!-- https://github.com/paragonie/random_compat/blob/master/lib/random_bytes_*.php -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.random_bytesFound"/>
+
+        <!-- https://github.com/paragonie/random_compat/blob/master/lib/random_int.php -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.random_intFound"/>
+
+        <!-- https://github.com/paragonie/random_compat/blob/master/lib/error_polyfill.php -->
+        <exclude name="PHPCompatibility.Classes.NewClasses.errorFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.typeerrorFound"/>
+    </rule>
+
+</ruleset>

--- a/PHPCompatibilityParagonieSodiumCompat/ruleset.xml
+++ b/PHPCompatibilityParagonieSodiumCompat/ruleset.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCompatibilityParagonieSodiumCompat">
+    <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Paragonie sodium_compat library.</description>
+
+    <!--
+        Note: this ruleset does **not** contain excludes for the `sodium_pwhash()` and
+        the sodium_memzero() functions as, while those functions do exist in the polyfill,
+        they do not work and are explicitly excluded features.
+        See: https://github.com/paragonie/sodium_compat#features-excluded-from-this-polyfill
+
+        With that in mind, these functions should not be used in code which intends to be
+        PHP cross-version compatible.
+    -->
+
+    <!-- https://github.com/paragonie/sodium_compat/blob/master/composer.json -->
+    <rule ref="PHPCompatibilityParagonieRandomCompat"/>
+
+    <rule ref="PHPCompatibility">
+        <!-- https://github.com/paragonie/sodium_compat/blob/master/src/SodiumException.php -->
+        <exclude name="PHPCompatibility.Classes.NewClasses.sodiumexceptionFound"/>
+
+        <!-- https://github.com/paragonie/sodium_compat/blob/master/lib/php72compat.php -->
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_chacha20poly1305_keybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_chacha20poly1305_nsecbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_chacha20poly1305_npubbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_chacha20poly1305_abytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_aes256gcm_keybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_aes256gcm_nsecbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_aes256gcm_npubbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_aes256gcm_abytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_keybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_nsecbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_npubbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_aead_chacha20poly1305_ietf_abytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_auth_bytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_auth_keybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_box_sealbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_box_secretkeybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_box_publickeybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_box_keypairbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_box_macbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_box_noncebytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_box_seedbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_kx_bytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_kx_publickeybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_kx_secretkeybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_kx_seedbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_generichash_bytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_generichash_bytes_minFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_generichash_bytes_maxFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_generichash_keybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_generichash_keybytes_minFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_generichash_keybytes_maxFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_pwhash_saltbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_pwhash_strprefixFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_pwhash_alg_argon2i13Found"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_pwhash_alg_argon2id13Found"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_pwhash_memlimit_interactiveFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_pwhash_opslimit_interactiveFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_pwhash_memlimit_moderateFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_pwhash_opslimit_moderateFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_pwhash_memlimit_sensitiveFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_pwhash_opslimit_sensitiveFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_scalarmult_bytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_scalarmult_scalarbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_shorthash_bytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_shorthash_keybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_secretbox_keybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_secretbox_macbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_secretbox_noncebytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_sign_bytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_sign_seedbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_sign_publickeybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_sign_secretkeybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_sign_keypairbytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_stream_keybytesFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.sodium_crypto_stream_noncebytesFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_bin2hexFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_compareFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_aes256gcm_decryptFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_aes256gcm_encryptFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_aes256gcm_is_availableFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_chacha20poly1305_decryptFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_chacha20poly1305_encryptFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_chacha20poly1305_keygenFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_chacha20poly1305_ietf_decryptFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_chacha20poly1305_ietf_encryptFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_chacha20poly1305_ietf_keygenFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_xchacha20poly1305_ietf_decryptFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_xchacha20poly1305_ietf_encryptFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_aead_xchacha20poly1305_ietf_keygenFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_authFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_auth_keygenFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_auth_verifyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_boxFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_box_keypairFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_box_keypair_from_secretkey_and_publickeyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_box_openFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_box_publickeyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_box_publickey_from_secretkeyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_box_sealFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_box_seal_openFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_box_secretkeyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_box_seed_keypairFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_generichashFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_generichash_finalFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_generichash_initFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_generichash_keygenFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_generichash_updateFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_kxFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_pwhash_strFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_pwhash_str_verifyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_pwhash_scryptsalsa208sha256Found"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_pwhash_scryptsalsa208sha256_strFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_pwhash_scryptsalsa208sha256_str_verifyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_scalarmultFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_scalarmult_baseFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_secretboxFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_secretbox_keygenFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_secretbox_openFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_shorthashFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_shorthash_keygenFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_signFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_detachedFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_keypairFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_openFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_publickeyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_publickey_from_secretkeyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_secretkeyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_seed_keypairFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_verify_detachedFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_ed25519_pk_to_curve25519Found"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_ed25519_sk_to_curve25519Found"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_streamFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_stream_keygenFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_stream_xorFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_hex2binFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_incrementFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_library_version_majorFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_library_version_minorFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_version_stringFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_memcmpFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_randombytes_bufFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_randombytes_uniformFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sodium_randombytes_random16Found"/>
+    </rule>
+
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,103 @@
+[![Latest Stable Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-paragonie/v/stable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-paragonie)
+[![Latest Unstable Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-paragonie/v/unstable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-paragonie)
+[![License](https://poser.pugx.org/phpcompatibility/phpcompatibility-paragonie/license.png)](https://github.com/PHPCompatibility/PHPCompatibilityParagonie/blob/master/LICENSE)
+[![Build Status](https://travis-ci.org/PHPCompatibility/PHPCompatibilityParagonie.svg?branch=master)](https://travis-ci.org/PHPCompatibility/PHPCompatibilityParagonie)
+
 # PHPCompatibilityParagonie
-PHPCompatibility rulesets which can be included in projects using the Paragonie polyfill libraries
+
+Using PHPCompatibilityParagonie, you can analyse the codebase of a project using either of the Paragonie polyfills, for PHP cross-version compatibility.
+
+
+## What's in this repo ?
+
+Two rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.
+
+These rulesets prevent false positives from the [PHPCompatibility standard](https://github.com/PHPCompatibility/PHPCompatibility) by excluding back-fills and poly-fills which are provided by those libraries.
+
+Paragonie Polyfill Library | Corresponding PHPCompatibility Ruleset | Includes
+--- | --- | ---
+[`random_compat`](https://github.com/paragonie/random_compat) | `PHPCompatibilityParagonieRandomCompat`
+[`sodium_compat`](https://github.com/paragonie/sodium_compat) | `PHPCompatibilityParagonieSodiumCompat` | `PHPCompatibilityParagonieRandomCompat`
+
+> Note:
+> As the `sodium_compat` library has `random_compat` [as a dependency](https://github.com/paragonie/sodium_compat/blob/master/composer.json), the `PHPCompatibilityParagonieSodiumCompat` ruleset includes the `PHPCompatibilityParagonieRandomCompat` ruleset.
+>
+> In practice, this means that if your project uses both libraries, you just need to use the `PHPCompatibilityParagonieSodiumCompat` ruleset to prevent false positives from both.
+
+
+## Requirements
+
+* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
+    * PHP 5.3+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 2.3.0+.
+    * PHP 5.4+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 3.0.2+.
+
+    Use the latest stable release of PHP_CodeSniffer for the best results.
+    The minimum _recommended_ version of PHP_CodeSniffer is version 2.6.0.
+* [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) 9.0.0+.
+
+
+## Installation instructions
+
+The only supported installation method is via [Composer](https://getcomposer.org/).
+
+If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
+```bash
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.4 phpcompatibility/phpcompatibility-paragonie:*
+composer install
+```
+
+If you already have a Composer PHP_CodeSniffer plugin installed, run:
+```bash
+composer require --dev phpcompatibility/phpcompatibility-paragonie:*
+composer install
+```
+
+Next, run:
+```bash
+vendor/bin/phpcs -i
+```
+If all went well, you will now see that the `PHPCompatibility`, `PHPCompatibilityParagonieRandomCompat` and `PHPCompatibilityParagonieSodiumCompat` standards are installed for PHP_CodeSniffer.
+
+
+## How to use
+
+Now you can use the following commands to inspect the code in your project for PHP cross-version compatibility:
+```bash
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityParagonieRandomCompat
+
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityParagonieSodiumCompat
+```
+
+By default, you will only receive notifications about deprecated and/or removed PHP features.
+
+To get the most out of the PHPCompatibilityParagonie rulesets, you should specify a `testVersion` to check against. That will enable the checks for both deprecated/removed PHP features as well as the detection of code using new PHP features.
+
+For example:
+```bash
+# For a project which should be compatible with PHP 5.3 up to and including PHP 7.0:
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityParagonieRandomCompat --runtime-set testVersion 5.3-7.0
+
+# For a project which should be compatible with PHP 5.4 and higher:
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityParagonieSodiumCompat --runtime-set testVersion 5.4-
+```
+
+For more detailed information about setting the `testVersion`, see the README of the generic [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions) standard.
+
+
+### Testing PHP files only
+
+By default PHP_CodeSniffer will analyse PHP, JavaScript and CSS files. As the PHPCompatibility sniffs only target PHP code, you can make the run slightly faster by telling PHP_CodeSniffer to only check PHP files, like so:
+```bash
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityParagonieRandomCompat --extensions=php --runtime-set testVersion 5.3-
+```
+
+## License
+
+All code within the PHPCompatibility organisation is released under the GNU Lesser General Public License (LGPL). For more information, visit https://www.gnu.org/copyleft/lesser.html
+
+
+## Changelog
+
+### 1.0.0 - 2018-10-07
+
+Initial release of PHPCompatibilityParagonie containing rulesets covering the `random_compat` and `sodium_compat` polyfill libraries.

--- a/Test/ParagonieRandomCompatTest.php
+++ b/Test/ParagonieRandomCompatTest.php
@@ -1,0 +1,13 @@
+<?php
+/*
+ * Test file to run PHP_CodeSniffer against to make sure the polyfills are correctly excluded.
+ */
+if ( PHP_VERSION_ID < 50600 ) {}
+
+$a = random_bytes();
+$a = random_int();
+
+try {
+} catch ( TypeError $e ) {
+} catch ( Error $e ) {
+}

--- a/Test/ParagonieSodiumCompatTest.php
+++ b/Test/ParagonieSodiumCompatTest.php
@@ -1,0 +1,13 @@
+<?php
+/*
+ * Test file to run PHP_CodeSniffer against to make sure the polyfills are correctly excluded.
+ *
+ * {@internal This file is incomplete and only does a spot check!}}
+ */
+try {
+	$a = sodium_crypto_pwhash_str();
+
+	echo SODIUM_CRYPTO_BOX_SEEDBYTES;
+
+} catch ( SodiumException $e ) {
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,31 @@
+{
+  "name" : "phpcompatibility/phpcompatibility-paragonie",
+  "description" : "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+  "type" : "phpcodesniffer-standard",
+  "keywords" : [ "compatibility", "phpcs", "standards", "paragonie", "polyfill" ],
+  "homepage" : "http://phpcompatibility.com/",
+  "license" : "LGPL-3.0-or-later",
+  "authors" : [ {
+    "name" : "Wim Godden",
+    "role" : "lead"
+  },
+  {
+    "name" : "Juliette Reinders Folmer",
+    "role" : "lead"
+  } ],
+  "support" : {
+    "issues" : "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+    "source" : "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+  },
+  "require" : {
+    "phpcompatibility/php-compatibility" : "^9.0"
+  },
+  "require-dev" : {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+  },
+  "suggest" : {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+    "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+  },
+  "prefer-stable" : true
+}


### PR DESCRIPTION
:warning: **IMPORTANT** :warning:
The build for this PR will not pass until PHPCompatibility 9.0.0 has been released.  This PR should not be merged until then. 

---
- Adds two rulesets for the polyfill libraries provided by Paragonie.
- Adds README with basic installation and usage instructions.
- Adds `composer.json` file which requires the PHPCompatibility standard and `dev` requires the DealerDirect PHPCS Composer plugin to install the standards for testing.
- Adds two minimal PHP files to test the rulesets against.
- Adds a Travis config to test the rulesets, validate the ruleset XML and the Composer configuration on each update.
- Adds `.gitignore` to ignore the `vendor` directory and the `composer.lock` file.
- Adds `.gitattributes` to keep release archives clean.
- Adds `.github/issue_template.md` to try and prevent issues related to the generic PHPCompatibility standard from being opened in this repository.