### PR TITLE
Ruleset: prevent false positives on random_compat polyfill code

### DIFF
--- a/PHPCompatibilityParagonieRandomCompat/ruleset.xml
+++ b/PHPCompatibilityParagonieRandomCompat/ruleset.xml
@@ -17,4 +17,24 @@
         <exclude name="PHPCompatibility.Classes.NewClasses.typeerrorFound"/>
     </rule>
 
+    <!-- Prevent false positives being thrown when run over the code of random_compat itself. -->
+    <rule ref="PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated">
+        <exclude-pattern>/random_compat/lib/byte_safe_strings\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.FunctionUse.NewFunctions.stream_set_chunk_sizeFound">
+        <exclude-pattern>/random_compat/lib/random_bytes_dev_urandom\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Constants.RemovedConstants.mcrypt_dev_urandomDeprecatedRemoved">
+        <exclude-pattern>/random_compat/lib/random_bytes_mcrypt\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Extensions.RemovedExtensions.mcryptDeprecatedRemoved">
+        <exclude-pattern>/random_compat/lib/random_bytes_mcrypt\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_create_ivDeprecatedRemoved">
+        <exclude-pattern>/random_compat/lib/random_bytes_mcrypt\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound">
+        <exclude-pattern>/random_compat/lib/random_bytes_libsodium\.php$</exclude-pattern>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
When [notifying the polyfill repos](https://github.com/paragonie/random_compat/issues/154) about the polyfill rulesets, I came across [this issue](https://github.com/paragonie/random_compat/issues/151) and figured we could fix that.

---

When `PHPCompatibility(ParagonieRandomCompat)` is run over the code in the `random_compat` repo itself, it will detect some non-issues.

The code in the files is all wrapped within proper `defined()`, `version_compare()` and/or `function_exists()` conditions and will never be executed on incompatible PHP versions.

This simple change prevents these non-issues from being reported.

This fix does rely on people having installed the package in a directory called `random_compat`.