### PR TITLE
Travis: add a check against false positives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ sudo: false
 
 dist: trusty
 
-cache:
-  apt: true
-
 language: php
 
 ## Cache composer downloads.
 cache:
+  apt: true
   directories:
     - $HOME/.cache/composer/files
 
@@ -42,8 +40,12 @@ script:
     fi
 
   # Test the rulesets.
-  - vendor/bin/phpcs ./Test/ParagonieRandomCompatTest.php --standard=PHPCompatibilityParagonieRandomCompat --runtime-set testVersion 5.2
-  - vendor/bin/phpcs ./Test/ParagonieSodiumCompatTest.php --standard=PHPCompatibilityParagonieSodiumCompat --runtime-set testVersion 5.3
+  - vendor/bin/phpcs ./Test/ParagonieRandomCompatTest.php --standard=PHPCompatibilityParagonieRandomCompat --runtime-set testVersion 5.2-
+  - vendor/bin/phpcs ./Test/ParagonieSodiumCompatTest.php --standard=PHPCompatibilityParagonieSodiumCompat --runtime-set testVersion 5.3-
+
+  # Check that the rulesets don't throw unnecessary errors for the compat libraries themselves.
+  - vendor/bin/phpcs ./vendor/paragonie/random_compat/ --standard=PHPCompatibilityParagonieRandomCompat --runtime-set testVersion 5.2- --ignore=/random_compat/tests/*,/random_compat/other/*
+  - vendor/bin/phpcs ./vendor/paragonie/sodium_compat/ --standard=PHPCompatibilityParagonieSodiumCompat --runtime-set testVersion 5.3- --ignore=/sodium_compat/tests/*
 
   # Validate the composer.json file.
   # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
     "phpcompatibility/php-compatibility" : "^9.0"
   },
   "require-dev" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+    "paragonie/random_compat": "dev-master",
+    "paragonie/sodium_compat": "dev-master"
   },
   "suggest" : {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",


### PR DESCRIPTION
This adds an additional check to the Travis build.

PR #2 added `exclude`s to the `RandomCompat` ruleset to prevent false positives being generated when the ruleset would be run against the code of the polyfill itself.

PR #11 does the same for the `SodiumCompat` ruleset.

As the polyfills may, of course, be updated over time, we need to ensure that these excludes are still sufficient.

This adds a `dev` dependency on the actual polyfills and a check to Travis to make sure that if the ruleset is run over the polyfill code, no errors are thrown.

**Note**: this check may start failing without notice because of changes in the polyfills, but that's exactly what this check is guarding against and will prevent us from releasing a version which doesn't have the right excludes in place.

In addition to this, an automatic weekly/monthly Travis run on `master` should be turned on to make sure this check is run on a semi-regular basis.
_For now, I've turned an automatic monthly check on_

Additionally:
* I've also merged the duplicate `cache` key in the Travis script.
* And the integration tests now run against an open-ended `testVersion`.

This PR can only be merged after PR #11 and should be rebased once PR #11 has been merged.