### PR TITLE
Ruleset: prevent false positives on sodium_compat polyfill code

### DIFF
--- a/PHPCompatibilityParagonieSodiumCompat/ruleset.xml
+++ b/PHPCompatibilityParagonieSodiumCompat/ruleset.xml
@@ -184,5 +184,8 @@
     <rule ref="PHPCompatibility.FunctionUse.NewFunctions.sodium_memzeroFound">
         <exclude-pattern>/sodium_compat/src/Compat\.php$</exclude-pattern>
     </rule>
+    <rule ref="PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated">
+        <exclude-pattern>/sodium_compat/src/Core/Util\.php$</exclude-pattern>
+    </rule>
 
 </ruleset>


### PR DESCRIPTION
Follow up on #11 which was missing one exclude.