### PR TITLE
Travis: minor tweak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-sudo: false
-
 dist: trusty
-
 language: php
 
 ## Cache composer downloads.


### PR DESCRIPTION
Sudo is no longer supported in Travis and hasn't been for a while.

N.B.: the build won't pass until PR #18 has been merged.