### PR TITLE
Travis: add build to test against PHPCompatibility `develop`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,35 @@ matrix:
   fast_finish: true
   include:
     - php: 7.4
+      env: LINT=1
       addons:
         apt:
           packages:
             - libxml2-utils
     - php: 5.4
 
+    - php: 7.4
+      env: PHPCOMPAT="dev-develop as 9.99.99"
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - env: PHPCOMPAT="dev-develop as 9.99.99"
+
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
   - export XMLLINT_INDENT="    "
+  - |
+    if [[ $PHPCOMPAT ]]; then
+      composer config minimum-stability dev
+      composer require --no-update phpcompatibility/php-compatibility:"${PHPCOMPAT}"
+    fi
   - composer install
   - vendor/bin/phpcs -i
 
 script:
   - |
-    if [[ $TRAVIS_PHP_VERSION == "7.4" ]]; then
+    if [[ $LINT == "1" ]]; then
       # Validate the xml files.
       # @link http://xmlsoft.org/xmllint.html
       xmllint --noout ./*/ruleset.xml


### PR DESCRIPTION
... to get early warning of things which need fixing in the polyfill ruleset(s) for the PHPCompatibility 10.0.0 release.

The build against `dev-develop` is allowed to fail.