### PR TITLE
Update version of Composer PHPCS plugin + fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
   - vendor/bin/phpcs ./Test/ParagonieSodiumCompatTest.php --standard=PHPCompatibilityParagonieSodiumCompat --runtime-set testVersion 5.3-
 
   # Check that the rulesets don't throw unnecessary errors for the compat libraries themselves.
-  - vendor/bin/phpcs ./vendor/paragonie/random_compat/ --standard=PHPCompatibilityParagonieRandomCompat --runtime-set testVersion 5.2- --ignore=/random_compat/tests/*,/random_compat/other/*
+  - vendor/bin/phpcs ./vendor/paragonie/random_compat/ --standard=PHPCompatibilityParagonieRandomCompat --runtime-set testVersion 5.2- --ignore=/random_compat/psalm-autoload.php,/random_compat/phpunit-autoload.php,/random_compat/tests/*,/random_compat/other/*
   - vendor/bin/phpcs ./vendor/paragonie/sodium_compat/ --standard=PHPCompatibilityParagonieSodiumCompat --runtime-set testVersion 5.3- --ignore=/sodium_compat/tests/*
 
   # Validate the composer.json file.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The only supported installation method is via [Composer](https://getcomposer.org
 
 If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
 ```bash
-composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.6 phpcompatibility/phpcompatibility-paragonie:*
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:"^0.7" phpcompatibility/phpcompatibility-paragonie:*
 composer install
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     "phpcompatibility/php-compatibility" : "^9.0"
   },
   "require-dev" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.6",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "paragonie/random_compat": "dev-master",
     "paragonie/sodium_compat": "dev-master"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
   "prefer-stable" : true


### PR DESCRIPTION
The DealerDirect Composer plugin has released version `0.7.0` a few months ago, which is compatible with Composer 2.x.
As Composer 2.0 has just been released, we should make sure not to recommend installing an older version of the plugin than `0.7.0`.

We also need to make sure we use the right version of the plugin ourselves in the `require-dev`.

As Composer treats minors < 1.0 as majors, updating to this version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats ^0.3 as >=0.3.0 <0.4.0.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.7.0
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-

---

I've added a second commit to account for some changes upstream. Adding it to this PR to allow the build to pass.

### Travis: fix the build

The Random Compat repo introduced two files, one which is specifically for Psalm, another for PHPUnit, neither is compatible with PHP 5.2.

These files are `export-ignore`-d in their `.gitattributes`, so will never be part of a distribution, so we can safely ignore them when testing the ruleset against the latest version of the polyfill.