### PR TITLE
Composer: allow the PHPCS plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,13 @@ The only supported installation method is via [Composer](https://getcomposer.org
 
 If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
 ```bash
+composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 composer require --dev dealerdirect/phpcodesniffer-composer-installer:"^0.7" phpcompatibility/phpcompatibility-paragonie:"*"
-composer install
 ```
 
 If you already have a Composer PHP_CodeSniffer plugin installed, run:
 ```bash
 composer require --dev phpcompatibility/phpcompatibility-paragonie:"*"
-composer install
 ```
 
 Next, run:

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,11 @@
     "issues" : "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
     "source" : "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
   },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  },
   "require" : {
     "phpcompatibility/php-compatibility" : "^9.0"
   },


### PR DESCRIPTION
The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution

---

### :new: README: update for Composer 2.2

Using the `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is recommended to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run.

This commit adds the CLI command to set those permissions to the installation instructions.

Includes removing a few redundant `composer install`s.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution